### PR TITLE
fix: update next-intl framework config

### DIFF
--- a/src/frameworks/next-intl.ts
+++ b/src/frameworks/next-intl.ts
@@ -79,10 +79,10 @@ class NextIntlFramework extends Framework {
     const ranges: ScopeRange[] = []
     const text = document.getText()
 
-    // Find matches of `useTranslations` and `getTranslator`. Later occurences will
+    // Find matches of `useTranslations` and `getTranslations`. Later occurences will
     // override previous ones (this allows for multiple components with different
     // namespaces in the same file).
-    const regex = /(useTranslations\(\s*|getTranslator\(.*,\s*)(['"`](.*?)['"`])?/g
+    const regex = /(useTranslations\(\s*|getTranslations\(.*,\s*)(['"`](.*?)['"`])?/g
     let prevGlobalScope = false
     for (const match of text.matchAll(regex)) {
       if (typeof match.index !== 'number')


### PR DESCRIPTION
This fixes the regex in `getScopeRange` function for the [Next-intl](https://next-intl-docs.vercel.app) framework.

One of the function names was incorrect.